### PR TITLE
Code refactoring: reduce duplicate code, convert some attributes to properties

### DIFF
--- a/pylobid/pylobid.py
+++ b/pylobid/pylobid.py
@@ -4,6 +4,7 @@ from jsonpath_ng import parse
 from . utils import extract_coords
 from typing import Union
 
+
 class PyLobidClient():
     """Main Class to interact with LOBID-API """
 
@@ -32,6 +33,10 @@ class PyLobidClient():
     @property
     def ent_type(self) -> list:
         return self.ent_dict.get('type', False)
+
+    @property
+    def same_as(self):
+        return self.get_same_as()
 
     def extract_id(self, url: str) -> Union[str, bool]:
         """extracts the GND-ID from an GND-URL
@@ -143,7 +148,6 @@ class PyLobidPlace(PyLobidClient):
         super().__init__(gnd_id)
         self.coords = self.get_coords()
         self.alt_names = self.get_alt_names()
-        self.same_as = self.get_same_as()
         self.pref_name = self.get_pref_name()
 
     def get_coords_str(self) -> str:
@@ -182,7 +186,6 @@ class PyLobidOrg(PyLobidClient):
         """
         super().__init__(gnd_id)
         self.alt_names = self.get_alt_names()
-        self.same_as = self.get_same_as()
         self.pref_name = self.get_pref_name()
         self.located_in = self.ent_dict.get('placeOfBusiness', [])
 
@@ -321,4 +324,4 @@ class PyLobidPerson(PyLobidClient):
             'alt_names': self.get_place_alt_name(place_of='Death')
         }
         self.life_span = self.get_life_dates()
-        self.same_as = self.get_same_as()
+

--- a/pylobid/pylobid.py
+++ b/pylobid/pylobid.py
@@ -20,22 +20,27 @@ class PyLobidClient():
 
     @property
     def is_place(self) -> bool:
+        """Return True if this instance is a place entity, False otherwise."""
         return 'PlaceOrGeographicName' in self.ent_type
 
     @property
     def is_org(self) -> bool:
+        """Return True if this instance is an organization entity, False otherwise."""
         return 'CorporateBody' in self.ent_type
 
     @property
     def is_person(self) -> bool:
+        """Return True if this instance is a person entity, False otherwise."""
         return 'Person' in self.ent_type
 
     @property
     def ent_type(self) -> list:
+        """Return the entity type."""
         return self.ent_dict.get('type', False)
 
     @property
-    def same_as(self):
+    def same_as(self) -> list:
+        """Return a list of alternative norm-data-ids."""
         return self.get_same_as()
 
     def extract_id(self, url: str) -> Union[str, bool]:
@@ -155,9 +160,9 @@ class PyLobidPlace(PyLobidClient):
         return coords_str
 
     def get_coords(self) -> list:
-        """get a list of coordiantes
+        """get a list of coordinates
 
-        :return: A list of longitute, latitude coords like ['+009.689780', '+051.210970']
+        :return: A list of longitude, latitude coords like ['+009.689780', '+051.210970']
         :rtype: list
 
         """

--- a/pylobid/pylobid.py
+++ b/pylobid/pylobid.py
@@ -84,13 +84,7 @@ class PyLobidClient():
         :return: A list of tuples like ('GeoNames', 'http://sws.geonames.org/2782067'),
         :rtype: list
         """
-        try:
-            result = [
-                (x['collection'].get('abbr', 'no_abbr'), x['id']) for x in self.ent_dict['sameAs']
-            ]
-        except KeyError as e:
-            result = []
-        return result
+        return [(x['collection'].get('abbr', 'no_abbr'), x['id']) for x in self.ent_dict['sameAs']]
 
     def get_pref_name(self) -> str:
         """ returns the preferred name

--- a/pylobid/pylobid.py
+++ b/pylobid/pylobid.py
@@ -231,12 +231,8 @@ class PyLobidPerson(PyLobidClient):
         :rtype: dict
 
         """
-        result = self.place_of_values(place_of)
-        if result:
-            place_id = result['id']
-            return PyLobidPerson(place_id).ent_dict
-        else:
-            return {}
+        place_id = self.place_of_values(place_of).get('id')
+        return {} if place_id is None else PyLobidPerson(place_id).ent_dict
 
     def get_coords_str(self, place_of: str = 'Birth') -> str:
         """get a string of coordinates

--- a/pylobid/pylobid.py
+++ b/pylobid/pylobid.py
@@ -7,14 +7,40 @@ from typing import Union
 class PyLobidClient():
     """Main Class to interact with LOBID-API """
 
+    @property
+    def gnd_id(self) -> str:
+        """Return the GND ID, e.g. 118650130"""
+        return self.__gnd_id
+
+    @property
+    def gnd_url(self) -> str:
+        """Return the GND URL e.g. http://d-nb.info/gnd/118650130"""
+        return f"{self.BASE_URL}/{self.gnd_id}" if self.gnd_id is not None else False
+
+    @property
+    def is_place(self) -> bool:
+        return 'PlaceOrGeographicName' in self.ent_type
+
+    @property
+    def is_org(self) -> bool:
+        return 'CorporateBody' in self.ent_type
+
+    @property
+    def is_person(self) -> bool:
+        return 'Person' in self.ent_type
+
+    @property
+    def ent_type(self) -> list:
+        return self.ent_dict.get('type', False)
+
     def extract_id(self, url: str) -> Union[str, bool]:
         """extracts the GND-ID from an GND-URL
 
         :param url: A GND-URL, e.g. http://d-nb.info/gnd/118650130
-        :type url: str, bool
+        :type url: str
 
         :return: The GND-ID, e.g. 118650130
-        :rtype: str
+        :rtype: str, bool
         """
         return next(iter(re.findall(self.ID_PATTERN, url)), False)
 
@@ -27,21 +53,21 @@ class PyLobidClient():
         :return: A LOBID-ENTITY-URL, e.g. http://lobid.org/gnd/116000562
         :rtype: str
         """
-        gnd_id = self.extract_id(url)
-        return f"{self.BASE_URL}/{gnd_id}" if gnd_id else False
+        self.__gnd_id = self.extract_id(url)
+        return self.gnd_url
 
-    def get_entity_json(self, url: str) -> dict:
+    def get_entity_json(self, url: str = None) -> dict:
         """fetches the LOBID-JSON response of a given GND-URL
 
         :param url: A GND_URL
-        :type url: str
+        :type url: str, optional
 
         :return: The matching JSON representation fetched from LOBID
         :rtype: dict
         """
-        request_url = self.get_entity_lobid_url(url)
+        url = self.gnd_url if url is None else self.get_entity_lobid_url(url)
         try:
-            response = requests.request("GET", request_url, headers=self.HEADERS)
+            response = requests.request("GET", url, headers=self.HEADERS)
         except requests.exceptions.RequestException as e:
             print(f"Request to LOBID-API for GND-URL {url} failed due to Error: {e}")
             return {}
@@ -83,7 +109,7 @@ class PyLobidClient():
     def __str__(self) -> str:
         return self.BASE_URL
 
-    def __init__(self) -> None:
+    def __init__(self, gnd_id: str = None) -> None:
         """Class constructor"""
         self.BASE_URL = "http://lobid.org/gnd"
         self.ID_PATTERN = "([0-9]\w*-*[0-9]\w*)"
@@ -93,6 +119,12 @@ class PyLobidClient():
         self.HEADERS = {
             'Accept': 'application/json'
         }
+        if gnd_id is not None:
+            _ = self.get_entity_lobid_url(gnd_id)
+            self.ent_dict = self.get_entity_json()
+        else:
+            self.__gnd_id = None
+            self.ent_dict = {}
 
 
 class PyLobidPlace(PyLobidClient):
@@ -108,11 +140,7 @@ class PyLobidPlace(PyLobidClient):
 
         :return: A PyLobidPlace instance
         """
-        super().__init__()
-        self.gnd_id = self.get_entity_lobid_url(gnd_id)
-        self.ent_dict = self.get_entity_json(gnd_id)
-        self.ent_type = self.ent_dict.get('type', False)
-        self.is_place = 'PlaceOrGeographicName' in self.ent_type
+        super().__init__(gnd_id)
         self.coords = self.get_coords()
         self.alt_names = self.get_alt_names()
         self.same_as = self.get_same_as()
@@ -152,11 +180,7 @@ class PyLobidOrg(PyLobidClient):
 
         :return: A PyLobidOrg instance
         """
-        super().__init__()
-        self.gnd_id = self.get_entity_lobid_url(gnd_id)
-        self.ent_dict = self.get_entity_json(gnd_id)
-        self.ent_type = self.ent_dict.get('type', False)
-        self.is_org = 'CorporateBody' in self.ent_type
+        super().__init__(gnd_id)
         self.alt_names = self.get_alt_names()
         self.same_as = self.get_same_as()
         self.pref_name = self.get_pref_name()
@@ -257,7 +281,7 @@ class PyLobidPerson(PyLobidClient):
         return next(iter([match.value for match in self.pref_alt_names_xpath.find(ent_dict)]), [])
 
     def __str__(self) -> str:
-        return self.gnd_id
+        return self.gnd_url
 
     def __init__(self, gnd_id: str, fetch_related: bool = False) -> None:
         """ initializes the class
@@ -269,11 +293,7 @@ class PyLobidPerson(PyLobidClient):
 
         :return: A PyLobidPerson instance
         """
-        super().__init__()
-        self.gnd_id = self.get_entity_lobid_url(gnd_id)
-        self.ent_dict = self.get_entity_json(gnd_id)
-        self.ent_type = self.ent_dict.get('type', False)
-        self.is_person = 'Person' in self.ent_type
+        super().__init__(gnd_id)
         if self.is_person:
             self.ent_dict.update(pylobid_born={}, pylobid_died={})
         self.pref_name = self.get_pref_name()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -62,6 +62,15 @@ TEST_IDS_ARRAY = [
     "http://lobid.org/gnd/4075434-0"
 ]
 
+TEST_URL_PARSER_ARRAY = [
+    ("http://d-nb.info/gnd/118650130", "118650130"),
+    ("http://d-nb.info/gnd/4003366-1", "4003366-1"),
+    ("https://d-nb.info/gnd/16254097-8", "16254097-8"),
+    ("141768134", "141768134"),
+    ("http://lobid.org/gnd/12328631X", "12328631X"),
+    ("http://lobid.org/gnd/4075434-0", "4075434-0")
+]
+
 TEST_STRINGS_WKT = [
     (
         "[[{'type': 'Point', 'asWKT': ['Point ( +023.599440 +038.463610 )']}]]",

--- a/tests/test_pylobid.py
+++ b/tests/test_pylobid.py
@@ -119,6 +119,16 @@ class TestPylobidClient(unittest.TestCase):
             f"should be {pl_client.BASE_URL}"
         )
 
+    def test_005_url_parser(self):
+        for input_str, id_str  in TEST_URL_PARSER_ARRAY:
+            pl_client = pl.PyLobidClient(input_str)
+            gnd_url = f"{pl_client.BASE_URL}/{id_str}"
+            self.assertEqual(
+                pl_client.gnd_url,
+                gnd_url,
+                f"gnd_url should be {gnd_url}"
+            )
+
 
 class TestPyLobidPerson(unittest.TestCase):
     """Tests for `pylobid` package."""


### PR DESCRIPTION
Move methods to the base class to reduce duplicate code and use properties. Until now the `gnd_id` attribute returns an URL. With the `gnd_id` and `gnd_url` properties now offer a clear separation. 

These changes do not break the API. 