### PR TITLE
Add a factory method to generate instances

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,8 +2,26 @@
 Usage
 =====
 
+Getting started
+---------------
+
+.. code-block:: python
+
+    from pylobid.pylobid import PyLobClient
+    gnd_id = "http://d-nb.info/gnd/119315122"
+    py_ent = PyLobidClient(gnd_id, fetch_related=True).factory()
+    print(repr(py_ent))
+    <PyLobidPerson http://lobid.org/gnd/119315122>
+
+`PyLobidClient().factory()` returns the following instances based on the provided entity type:
+
+- Type `PlaceOrGeographicName` returns a PyLobidPlace` instance.
+- Type `CorporateBody` returns a `PyLobidOrg` instance.
+- Type `Person` returns a `PyLobidPerson` instance.
+- All other types a `PyLobidPerson` instance
+
 Persons
---------
+-------
 
 To use pylobid in a project::
 
@@ -41,7 +59,7 @@ To use pylobid in a project::
 
 
 Places
---------
+------
 
 How to use PyLobidPlace object::
 
@@ -62,7 +80,7 @@ How to use PyLobidPlace object::
 
 
 Organisations
---------
+-------------
 
 How to use PyLobidOrg object::
 

--- a/pylobid/pylobid.py
+++ b/pylobid/pylobid.py
@@ -113,6 +113,9 @@ class PyLobidClient():
     def __str__(self) -> str:
         return self.BASE_URL
 
+    def __repr__(self) -> str:
+        return f'<PyLobidClient {self.gnd_url}>'
+
     def __init__(self, gnd_id: str = None) -> None:
         """Class constructor"""
         self.BASE_URL = "http://lobid.org/gnd"
@@ -169,6 +172,9 @@ class PyLobidPlace(PyLobidClient):
         coords_str = self.get_coords_str()
         return extract_coords(coords_str)
 
+    def __repr__(self) -> str:
+        return f'<PyLobidPlace {self.gnd_url}>'
+
 
 class PyLobidOrg(PyLobidClient):
     """ A python class representing an Organisation Entity """
@@ -187,6 +193,9 @@ class PyLobidOrg(PyLobidClient):
         self.alt_names = self.get_alt_names()
         self.pref_name = self.get_pref_name()
         self.located_in = self.ent_dict.get('placeOfBusiness', [])
+
+    def __repr__(self) -> str:
+        return f'<PyLobidOrg {self.gnd_url}>'
 
 
 class PyLobidPerson(PyLobidClient):
@@ -280,6 +289,9 @@ class PyLobidPerson(PyLobidClient):
 
     def __str__(self) -> str:
         return self.gnd_url
+
+    def __repr__(self) -> str:
+        return f'<PyLobidPerson {self.gnd_url}>'
 
     def __init__(self, gnd_id: str, fetch_related: bool = False) -> None:
         """ initializes the class

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -99,7 +99,6 @@ TEST_ORG_IDS = [
     ("http://lobid.org/gnd/4012995-0", False),
     ("https://d-nb.info/gnd/4056905-6", False),
     ('http://d-nb.info/gnd/4011750-9', True),
-    ('http://d-nb.info/gnd/4534475-9', True),
     ('http://d-nb.info/gnd/2168247-1', True),
     ('http://d-nb.info/gnd/82742-3', True),
     ('http://d-nb.info/gnd/11486-8', True),

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -106,6 +106,10 @@ TEST_ORG_IDS = [
     ('http://d-nb.info/gnd/1600912-5', True),
 ]
 
+TEST_FACTORY = [(element[0], "is_org") for element in TEST_ORG_IDS if element[1]]
+TEST_FACTORY += [(element[0], "is_place") for element in TEST_PLACE_IDS if element[1]]
+TEST_FACTORY += [(element['id'], "is_person") for element in TEST_PERSON_DICTS]
+
 TEST_ORG_NAMES_LOCATIONS = [
     {
         'id': 'http://d-nb.info/gnd/4443305-0',

--- a/tests/test_pylobid.py
+++ b/tests/test_pylobid.py
@@ -120,7 +120,7 @@ class TestPylobidClient(unittest.TestCase):
         )
 
     def test_005_url_parser(self):
-        for input_str, id_str  in TEST_URL_PARSER_ARRAY:
+        for input_str, id_str in TEST_URL_PARSER_ARRAY:
             pl_client = pl.PyLobidClient(input_str)
             gnd_url = f"{pl_client.BASE_URL}/{id_str}"
             self.assertEqual(
@@ -129,6 +129,13 @@ class TestPylobidClient(unittest.TestCase):
                 f"gnd_url should be {gnd_url}"
             )
 
+    def test_006_factory(self):
+        for gnd_id, entity_type in TEST_FACTORY:
+            entity_client = pl.PyLobidClient(gnd_id).factory()
+            self.assertTrue(
+                getattr(entity_client, entity_type),
+                f"Entity should be {entity_type}"
+            )
 
 class TestPyLobidPerson(unittest.TestCase):
     """Tests for `pylobid` package."""


### PR DESCRIPTION
Calling `PyLobidClient(gnd_id).instance()` fetches the data for the provided `gnd_id` and returns a matching instance. This is useful if you only have a GND Id or URL without any information about its type.

Example (also provided in the docs):
```
from pylobid.pylobid import PyLobClient
gnd_id = "http://d-nb.info/gnd/119315122"
py_ent = PyLobidClient(gnd_id, fetch_related=True).factory()
print(repr(py_ent))
<PyLobidPerson http://lobid.org/gnd/119315122>
```