### PR TITLE
Add exceptions

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -15,10 +15,18 @@ Getting started
 
 `PyLobidClient().factory()` returns the following instances based on the provided entity type:
 
-- Type `PlaceOrGeographicName` returns a PyLobidPlace` instance.
+- Type `PlaceOrGeographicName` returns a `PyLobidPlace` instance.
 - Type `CorporateBody` returns a `PyLobidOrg` instance.
 - Type `Person` returns a `PyLobidPerson` instance.
 - All other types a `PyLobidPerson` instance
+
+`PyLobidClient` and its derivatives can raise the following exceptions:
+
+- `GNDIdError` If the GND-ID cannot be parsed from the provided URL or ID string.
+- `GNDNotFoundError` If the GND cannot be found and the API endpoint responds with `404 Not Found`.
+- `GNDAPIError` If the API endpoint response code is anything other than 200 or 404.
+
+`GNDIdError` is a derivative of `ValueError`. All requests are done with the `requests` module and none of its exceptions are caught by this module.
 
 Persons
 -------

--- a/pylobid/pylobid.py
+++ b/pylobid/pylobid.py
@@ -5,6 +5,10 @@ from . utils import extract_coords
 from typing import Union
 
 
+class GNDIdError(ValueError):
+    """Exception raised if the GND-ID is invalid."""
+
+
 class PyLobidClient():
     """Main Class to interact with LOBID-API """
 
@@ -88,12 +92,13 @@ class PyLobidClient():
         :param url: A GND-URL, e.g. http://d-nb.info/gnd/118650130
         :type url: str
 
+        :raises: GNDIdError
         :return: The GND-ID, e.g. 118650130
         :rtype: str, bool
         """
         gnd_id = re.search(self.ID_PATTERN, url)
         if gnd_id is None:
-            raise ValueError(f'Could not find GND Id in "{url}"')
+            raise GNDIdError(f'Could not find GND-ID in "{url}"')
         return gnd_id.group()
 
     def get_entity_lobid_url(self, url: str) -> str:

--- a/pylobid/pylobid.py
+++ b/pylobid/pylobid.py
@@ -121,9 +121,10 @@ class PyLobidClient():
         try:
             response = requests.request("GET", url, headers=self.HEADERS)
         except requests.exceptions.RequestException as e:
-            print(f"Request to LOBID-API for GND-URL {url} failed due to Error: {e}")
-            return {}
-        return response.json() if response.ok else {}
+            raise e from None
+        if not response.ok:
+            raise ValueError(f'Could not find a GND Entity for Id "{self.gnd_id}"')
+        return response.json()
 
     def get_same_as(self) -> list:
         """ returns a list of alternative norm-data-ids

--- a/pylobid/pylobid.py
+++ b/pylobid/pylobid.py
@@ -9,6 +9,13 @@ class GNDIdError(ValueError):
     """Exception raised if the GND-ID is invalid."""
 
 
+class GNDNotFoundError(Exception):
+    """Exception raised if the API returns Not Found for a GND-ID"""
+
+
+class GNDAPIError(Exception):
+    """Broad exception if something unexpected happens."""
+
 class PyLobidClient():
     """Main Class to interact with LOBID-API """
 
@@ -127,8 +134,10 @@ class PyLobidClient():
             response = requests.request("GET", url, headers=self.HEADERS)
         except requests.exceptions.RequestException as e:
             raise e from None
-        if not response.ok:
-            raise ValueError(f'Could not find a GND Entity for Id "{self.gnd_id}"')
+        if response.status_code == 404:
+            raise GNDNotFoundError(f'Could not find a GND Entity for ID "{self.gnd_id}"')
+        elif not response.ok:
+            raise GNDAPIError(f'GND API error code: {response.status_code}')
         return response.json()
 
     def get_same_as(self) -> list:

--- a/pylobid/pylobid.py
+++ b/pylobid/pylobid.py
@@ -91,7 +91,10 @@ class PyLobidClient():
         :return: The GND-ID, e.g. 118650130
         :rtype: str, bool
         """
-        return next(iter(re.findall(self.ID_PATTERN, url)), False)
+        gnd_id = re.search(self.ID_PATTERN, url)
+        if gnd_id is None:
+            raise ValueError(f'Could not find GND Id in "{url}"')
+        return gnd_id.group()
 
     def get_entity_lobid_url(self, url: str) -> str:
         """creates a lobid-entity URL from an GND-URL

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -11,7 +11,10 @@ TEST_PERSON_DICTS = [
             'name': 'Wien',
             'coords': ['+016.371690', '+048.208199']
         },
-        'life_span': {'birth_date_str': '1873-12-23', 'death_date_str': '1933-03-15'}
+        'life_span': {
+            'birth_date_str': '1873-12-23',
+            'death_date_str': '1933-03-15'
+        }
     },
     {
         'id': "http://d-nb.info/gnd/116586869",
@@ -21,7 +24,10 @@ TEST_PERSON_DICTS = [
         'pylobid_died': {
             'id': ''
         },
-        'life_span': {'birth_date_str': '1874', 'death_date_str': ''}
+        'life_span': {
+            'birth_date_str': '1874',
+            'death_date_str': ''
+        }
     },
     {
         'id': "1069009253",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -43,6 +43,18 @@ TEST_PERSON_DICTS = [
     }
 ]
 
+TEST_INVALID_URLS = [
+    "?!invalid_id",
+    "example.com/",
+    "https://dnb.de",
+    "",
+    "http://lobid.org/gnd"
+]
+
+TEST_UNKNOWN_IDS = [
+    "01234-4321",
+    "0123abc-0123def"
+]
 
 TEST_IDS_DICT = {
     "persons": [

--- a/tests/test_pylobid.py
+++ b/tests/test_pylobid.py
@@ -137,6 +137,19 @@ class TestPylobidClient(unittest.TestCase):
                 f"Entity should be {entity_type}"
             )
 
+    def test_007_invalid_urls(self):
+        for gnd_url in TEST_INVALID_URLS:
+            with self.subTest(gnd_url=gnd_url):
+                with self.assertRaises(pl.GNDIdError):
+                    _ = pl.PyLobidClient(gnd_url)
+
+    def test_008_unkown_ids(self):
+        for gnd_id in TEST_UNKNOWN_IDS:
+            with self.subTest(gnd_id=gnd_id):
+                with self.assertRaises(pl.GNDNotFoundError):
+                    _ = pl.PyLobidClient(gnd_id)
+
+
 class TestPyLobidPerson(unittest.TestCase):
     """Tests for `pylobid` package."""
 

--- a/tests/test_pylobid.py
+++ b/tests/test_pylobid.py
@@ -1,63 +1,56 @@
 #!/usr/bin/env python
-
 """Tests for `pylobid` package."""
 
-
 import unittest
-
-from . fixtures import *
-
 from pylobid import utils
 from pylobid import pylobid as pl
+from .fixtures import *
 
 
 class TestUtilsFunctions(unittest.TestCase):
+    """Tests for utils package."""
+
     def test_000_extract_points(self):
-        test_strings = TEST_STRINGS_WKT
-        for x in test_strings:
-            points = utils.extract_coords(x[0])
-            self.assertEqual(points[0], x[1][0], f"should be {x[0][0]}")
-            self.assertEqual(points[1], x[1][1], f"should be {x[1][1]}")
+        for item in TEST_STRINGS_WKT:
+            points = utils.extract_coords(item[0])
+            self.assertEqual(points[0], item[1][0], f"should be {item[0][0]}")
+            self.assertEqual(points[1], item[1][1], f"should be {item[1][1]}")
 
 
 class TestPylobidPlace(unittest.TestCase):
     """Tests for `pylobid` package."""
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        """Tear down test fixtures, if any."""
-
     def test_000_check_type(self):
-        for x in TEST_PLACE_IDS:
-            pl_place = pl.PyLobidPlace(x[0], fetch_related=False)
-            self.assertEqual(pl_place.is_place, x[1], f"should be {x[1]}")
+        for item in TEST_PLACE_IDS:
+            with self.subTest(place_id=item[0]):
+                pl_place = pl.PyLobidPlace(item[0], fetch_related=False)
+                self.assertEqual(pl_place.is_place, item[1], f"should be {item[1]}")
 
     def test_001_check_coords_type(self):
-        for x in TEST_PLACE_IDS:
-            pl_place = pl.PyLobidPlace(x[0], fetch_related=False)
-            self.assertEqual(type(pl_place.coords), list, f"should be a list")
+        for item in TEST_PLACE_IDS:
+            with self.subTest(place_id=item[0]):
+                pl_place = pl.PyLobidPlace(item[0], fetch_related=False)
+                self.assertEqual(type(pl_place.coords), list, "should be a list")
 
     def test_002_check_coords(self):
-        id = "https://d-nb.info/gnd/4066009-6"
+        gnd_id = "https://d-nb.info/gnd/4066009-6"
         coords = ['+016.371690', '+048.208199']
-        pl_place = pl.PyLobidPlace(id, fetch_related=False)
+        pl_place = pl.PyLobidPlace(gnd_id, fetch_related=False)
         self.assertEqual(pl_place.coords, coords, f"should be {coords}")
 
     def test_003_check_alt_names(self):
-        id = "https://d-nb.info/gnd/4004168-2"
+        gnd_id = "https://d-nb.info/gnd/4004168-2"
         alt_names = [
             'Baden, Wienerwald',
             'Baden bei Wien',
             'Stadtgemeinde Baden',
             'Stadtgemeinde Baden bei Wien'
         ]
-        pl_place = pl.PyLobidPlace(id, fetch_related=False)
+        pl_place = pl.PyLobidPlace(gnd_id, fetch_related=False)
         self.assertEqual(pl_place.alt_names, alt_names, f"should be {alt_names}")
 
     def test_004_same_as(self):
-        id = "https://d-nb.info/gnd/4004168-2"
+        gnd_id = "https://d-nb.info/gnd/4004168-2"
         same_as = [
             # ('GeoNames', 'http://sws.geonames.org/2782067'),
             ('VIAF', 'http://viaf.org/viaf/234093638'),
@@ -65,77 +58,67 @@ class TestPylobidPlace(unittest.TestCase):
             ('DNB', 'https://d-nb.info/gnd/2005587-0'),
             ('dewiki', 'https://de.wikipedia.org/wiki/Bahnhof_Baden_bei_Wien'),
         ]
-        pl_place = pl.PyLobidPlace(id, fetch_related=False)
-        for x in same_as:
-            self.assertTrue(x in pl_place.same_as)
+        pl_place = pl.PyLobidPlace(gnd_id, fetch_related=False)
+        for item in same_as:
+            with self.subTest(same_as=item):
+                self.assertTrue(item in pl_place.same_as)
 
     def test_005_pref_name(self):
-        id = "https://d-nb.info/gnd/4004168-2"
+        gnd_id = "https://d-nb.info/gnd/4004168-2"
         pref_name = 'Baden (Niederösterreich)'
-        pl_place = pl.PyLobidPlace(id, fetch_related=False)
+        pl_place = pl.PyLobidPlace(gnd_id, fetch_related=False)
         self.assertEqual(pl_place.pref_name, pref_name, f"should be {pref_name}")
 
     def test_006_alt_name(self):
-        id = "https://d-nb.info/gnd/4004168-2"
+        gnd_id = "https://d-nb.info/gnd/4004168-2"
         alt_names = [
             "Baden, Wienerwald",
             "Baden bei Wien",
             "Stadtgemeinde Baden",
             "Stadtgemeinde Baden bei Wien"
         ]
-        pl_place = pl.PyLobidPlace(id, fetch_related=False)
-        for x in alt_names:
-            self.assertTrue(
-                x in pl_place.alt_names
-            )
+        pl_place = pl.PyLobidPlace(gnd_id, fetch_related=False)
+        for item in alt_names:
+            with self.subTest(alt_name=item):
+                self.assertTrue(item in pl_place.alt_names)
 
 
 class TestPylobidClient(unittest.TestCase):
     """Tests for `pylobid` package."""
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        """Tear down test fixtures, if any."""
-
     def test_001_get_entity_lobid_url(self):
         pl_client = pl.PyLobidClient()
-        for x in TEST_IDS_ARRAY:
-            lobid_url = pl_client.get_entity_lobid_url(x)
-            self.assertEqual(lobid_url[0], 'h', "should be 'h'")
+        for item in TEST_IDS_ARRAY:
+            with self.subTest(gnd_str=item):
+                lobid_url = pl_client.get_entity_lobid_url(item)
+                self.assertEqual(lobid_url[0], 'h', "should be 'h'")
 
     def test_002_get_lobid_json(self):
         pl_client = pl.PyLobidClient()
-        for x in TEST_IDS_ARRAY:
-            lobid_json = pl_client.get_entity_json(x)
-            self.assertEqual(type(lobid_json), dict, f"{type(lobid_json)} should be a dict")
+        for item in TEST_IDS_ARRAY:
+            with self.subTest(gnd_str=item):
+                lobid_json = pl_client.get_entity_json(item)
+                self.assertEqual(type(lobid_json), dict, f"{type(lobid_json)} should be a dict")
 
     def test_003_str(self):
         pl_client = pl.PyLobidClient()
-        self.assertEqual(
-            pl_client.__str__(),
-            pl_client.BASE_URL,
-            f"should be {pl_client.BASE_URL}"
-        )
+        self.assertEqual(pl_client.__str__(), pl_client.BASE_URL, f"should be {pl_client.BASE_URL}")
 
     def test_005_url_parser(self):
         for input_str, id_str in TEST_URL_PARSER_ARRAY:
-            pl_client = pl.PyLobidClient(input_str)
-            gnd_url = f"{pl_client.BASE_URL}/{id_str}"
-            self.assertEqual(
-                pl_client.gnd_url,
-                gnd_url,
-                f"gnd_url should be {gnd_url}"
-            )
+            with self.subTest(input_str=input_str, id_str=id_str):
+                pl_client = pl.PyLobidClient(input_str)
+                gnd_url = f"{pl_client.BASE_URL}/{id_str}"
+                self.assertEqual(pl_client.gnd_url, gnd_url, f"gnd_url should be {gnd_url}")
 
     def test_006_factory(self):
         for gnd_id, entity_type in TEST_FACTORY:
-            entity_client = pl.PyLobidClient(gnd_id).factory()
-            self.assertTrue(
-                getattr(entity_client, entity_type),
-                f"Entity should be {entity_type}"
-            )
+            with self.subTest(gnd_id=gnd_id, entity_type=entity_type):
+                entity_client = pl.PyLobidClient(gnd_id).factory()
+                self.assertTrue(
+                    getattr(entity_client, entity_type),
+                    f"Entity should be {entity_type}"
+                )
 
     def test_007_invalid_urls(self):
         for gnd_url in TEST_INVALID_URLS:
@@ -143,7 +126,7 @@ class TestPylobidClient(unittest.TestCase):
                 with self.assertRaises(pl.GNDIdError):
                     _ = pl.PyLobidClient(gnd_url)
 
-    def test_008_unkown_ids(self):
+    def test_008_unknown_ids(self):
         for gnd_id in TEST_UNKNOWN_IDS:
             with self.subTest(gnd_id=gnd_id):
                 with self.assertRaises(pl.GNDNotFoundError):
@@ -153,93 +136,73 @@ class TestPylobidClient(unittest.TestCase):
 class TestPyLobidPerson(unittest.TestCase):
     """Tests for `pylobid` package."""
 
-    def setUp(self):
-        """Set up test fixtures, if any."""
-
-    def tearDown(self):
-        """Tear down test fixtures, if any."""
-
     def test_000_ent_type(self):
-        ids = TEST_IDS_ARRAY
-        for x in ids:
-            pl_ent = pl.PyLobidPerson(x)
-            self.assertEqual(
-                type(pl_ent.ent_type),
-                list,
-                f"type of {pl_ent.ent_type} should be a list"
-            )
+        for item in TEST_IDS_ARRAY:
+            with self.subTest(gnd_id=item):
+                pl_ent = pl.PyLobidPerson(item)
+                self.assertEqual(
+                    type(pl_ent.ent_type),
+                    list,
+                    f"type of {pl_ent.ent_type} should be a list"
+                )
 
     def test_001_str(self):
         lobid_url = "http://lobid.org/gnd/4075434-0"
         pl_ent = pl.PyLobidPerson(lobid_url)
-        self.assertEqual(
-            pl_ent.__str__(),
-            lobid_url,
-            f"should be {lobid_url}"
-        )
+        self.assertEqual(pl_ent.__str__(), lobid_url, f"should be {lobid_url}")
 
     def test_002_is_person(self):
-        ids = TEST_IDS_DICT['persons']
-        for x in ids:
-            pl_ent = pl.PyLobidPerson(x)
-            self.assertTrue(
-                pl_ent.is_person
-            )
+        for item in TEST_IDS_DICT['persons']:
+            with self.subTest(gnd_id=item):
+                pl_ent = pl.PyLobidPerson(item)
+                self.assertTrue(pl_ent.is_person)
 
     def test_003_born_died_keys(self):
-        ids = TEST_IDS_ARRAY
-        for x in ids:
-            pl_ent = pl.PyLobidPerson(x)
-            if pl_ent.is_person:
-                ent_dict = pl_ent.ent_dict
-                self.assertTrue('pylobid_born' in ent_dict.keys())
+        for item in TEST_IDS_ARRAY:
+            with self.subTest(gnd_id=item):
+                pl_ent = pl.PyLobidPerson(item)
+                if pl_ent.is_person:
+                    ent_dict = pl_ent.ent_dict
+                    self.assertTrue('pylobid_born' in ent_dict.keys())
 
     def test_004_born_died_keys(self):
-        for x in TEST_PERSON_DICTS:
-            pl_ent = pl.PyLobidPerson(
-                x['id'],
-                fetch_related=True
-            )
-            self.assertEqual(
-                pl_ent.ent_dict['pylobid_born'].get('id', ''),
-                x['pylobid_born']['id'],
-                f"should be: {x['pylobid_born']['id']}"
-            )
-            self.assertEqual(
-                pl_ent.ent_dict['pylobid_died'].get('id', ''),
-                x['pylobid_died']['id'],
-                f"should be: {x['pylobid_died']['id']}"
-            )
+        for item in TEST_PERSON_DICTS:
+            with self.subTest(person=item):
+                pl_ent = pl.PyLobidPerson(item['id'], fetch_related=True)
+                self.assertEqual(
+                    pl_ent.ent_dict['pylobid_born'].get('id', ''),
+                    item['pylobid_born']['id'],
+                    f"should be: {item['pylobid_born']['id']}"
+                )
+                self.assertEqual(
+                    pl_ent.ent_dict['pylobid_died'].get('id', ''),
+                    item['pylobid_died']['id'],
+                    f"should be: {item['pylobid_died']['id']}"
+                )
 
     def test_005_lifespans(self):
-        for x in TEST_PERSON_DICTS:
-            pl_ent = pl.PyLobidPerson(
-                x['id']
-            )
-            lifespan = pl_ent.get_life_dates()
-            if 'life_span' in x.keys():
-                self.assertEqual(
-                    lifespan, x['life_span'],
-                    f"should be {x['life_span']}"
-                )
-            else:
-                self.assertEqual(
-                    type(lifespan), dict, "should be a dict"
-                )
+        for item in TEST_PERSON_DICTS:
+            with self.subTest(person=item):
+                pl_ent = pl.PyLobidPerson(item['id'])
+                lifespan = pl_ent.get_life_dates()
+                if 'life_span' in item.keys():
+                    self.assertEqual( lifespan, item['life_span'], f"should be {item['life_span']}")
+                else:
+                    self.assertEqual(type(lifespan), dict, "should be a dict")
 
     def test_006_same_as(self):
-        id = "1069009253"
+        gnd_id = "1069009253"
         same_as = [
             ('VIAF', 'http://viaf.org/viaf/120106865'),
             ('DNB', 'https://d-nb.info/gnd/1069009253/about')
         ]
-        pl_ent = pl.PyLobidPerson(id, fetch_related=False)
+        pl_ent = pl.PyLobidPerson(gnd_id, fetch_related=False)
         self.assertEqual(pl_ent.same_as, same_as, f"should be {same_as}")
 
     def test_007_pref_name(self):
-        id = "http://d-nb.info/gnd/1069009253"
+        gnd_id = "http://d-nb.info/gnd/1069009253"
         pref_name = 'Assmann, Richard'
-        pl_item = pl.PyLobidPerson(id, fetch_related=False)
+        pl_item = pl.PyLobidPerson(gnd_id, fetch_related=False)
         self.assertEqual(pl_item.pref_name, pref_name, f"should be {pref_name}")
 
 
@@ -247,18 +210,20 @@ class TestPylobidOrg(unittest.TestCase):
     """Tests for `pylobid` package."""
 
     def test_001_pref_name(self):
-        for x in TEST_ORG_NAMES_LOCATIONS:
-            item = pl.PyLobidOrg(x['id'])
-            self.assertEqual(
-                item.pref_name,
-                x['pref_name'], f"{item.pref_name} should be {x['pref_name']}"
-            )
+        for item in TEST_ORG_NAMES_LOCATIONS:
+            with self.subTest(org=item):
+                pl_item = pl.PyLobidOrg(item['id'])
+                self.assertEqual(
+                    pl_item.pref_name,
+                    item['pref_name'], f"{pl_item.pref_name} should be {item['pref_name']}"
+                )
 
     def test_002_located_in(self):
-        for x in TEST_ORG_NAMES_LOCATIONS:
-            item = pl.PyLobidOrg(x['id'])
-            self.assertEqual(
-                item.located_in,
-                x['located_in'],
-                f"{item.located_in} should be {x['located_in']}"
-            )
+        for item in TEST_ORG_NAMES_LOCATIONS:
+            with self.subTest(org=item):
+                pl_item = pl.PyLobidOrg(item['id'])
+                self.assertEqual(
+                    pl_item.located_in,
+                    item['located_in'],
+                    f"{pl_item.located_in} should be {item['located_in']}"
+                )


### PR DESCRIPTION
The following behavior changes are introduced:
* exceptions from the `requests` module are no longer catched 2350a0d
* if no GND-ID is found in the input string, raise GNDIdError 1d6743e
* if the API returns 404 Not Found, raise GNDNotFoundError c7aea29
* raise GNDAPIError if anything else than 200 or 404 is returned from the API endpoint 1d6743e

Refactor tests and introduce subtests. 